### PR TITLE
fix for iPad imagepicker crash

### DIFF
--- a/INaturalistIOS/ObservationDetailViewController.h
+++ b/INaturalistIOS/ObservationDetailViewController.h
@@ -60,6 +60,7 @@
 @property (nonatomic, strong) NSTimer *locationTimer;
 @property (nonatomic, strong) CLGeocoder *geocoder;
 @property (nonatomic, strong) UIDatePicker *datePicker;
+@property (nonatomic, strong) UIPopoverController *popOver;
 @property (nonatomic, strong) UIActionSheet *currentActionSheet;
 @property (nonatomic, assign) BOOL locationUpdatesOn;
 @property (nonatomic, assign) BOOL observationWasNew;

--- a/INaturalistIOS/ObservationDetailViewController.m
+++ b/INaturalistIOS/ObservationDetailViewController.m
@@ -53,6 +53,7 @@ static const int ProjectsSection = 5;
 @synthesize locationTimer = _locationTimer;
 @synthesize geocoder = _geocoder;
 @synthesize datePicker = _datePicker;
+@synthesize popOver = _popOver;
 @synthesize currentActionSheet = _currentActionSheet;
 @synthesize locationUpdatesOn = _locationUpdatesOn;
 @synthesize observationWasNew = _observationWasNew;
@@ -449,7 +450,16 @@ static const int ProjectsSection = 5;
     UIImagePickerController *ipc = [[UIImagePickerController alloc] init];
     [ipc setDelegate:self];
     [ipc setSourceType:sourceType];
-    [self presentModalViewController:ipc animated:YES];
+    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+        UIPopoverController *popover = [[UIPopoverController alloc] initWithContentViewController:ipc];
+        [popover presentPopoverFromRect:CGRectMake(0.0, 0.0, 0.0, 0.0)
+                                 inView:self.view
+               permittedArrowDirections:UIPopoverArrowDirectionAny
+                               animated:YES];
+        self.popOver = popover;
+    } else {
+        [self presentModalViewController:ipc animated:YES];
+    }
 }
 
 - (void)locationActionSheet:(UIActionSheet *)actionSheet clickedButtonAtIndex:(NSInteger)buttonIndex


### PR DESCRIPTION
Fix for crash on iPad - UIImagePickerController must be presented in a UIPopoverController.
