### PR TITLE
Make upload a background task

### DIFF
--- a/INaturalistIOS/UploadManager.h
+++ b/INaturalistIOS/UploadManager.h
@@ -33,6 +33,8 @@
 
 @property (nonatomic, weak) id <UploadManagerNotificationDelegate> delegate;
 
+@property UIBackgroundTaskIdentifier backgroundTask;
+
 - (void)syncDeletedRecords:(NSArray *)deletedRecords thenUploadObservations:(NSArray *)recordsToUpload;
 - (void)uploadObservations:(NSArray *)observations;
 - (void)cancelSyncsAndUploads;

--- a/INaturalistIOS/UploadManager.m
+++ b/INaturalistIOS/UploadManager.m
@@ -202,6 +202,12 @@
     RKObjectLoaderBlock loaderBlock = nil;
     INatModel <Uploadable> *recordToUpload = nil;
     
+    // create a background task, so that the upload can finish when the app goes to the background
+    self.backgroundTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
+        [[UIApplication sharedApplication] endBackgroundTask:self.backgroundTask];
+        self.backgroundTask = UIBackgroundTaskInvalid;
+    }];
+    
     if (observation.needsSync) {
         // upload the observation itself
         loaderBlock = ^(RKObjectLoader *loader) {
@@ -451,6 +457,9 @@
         [self.failedObjectLoaders removeObject:objectLoader];
     });
     
+    [[UIApplication sharedApplication] endBackgroundTask:self.backgroundTask];
+    self.backgroundTask = UIBackgroundTaskInvalid;
+    
     // if we've stopped uploading (ie due to an auth failure), ignore the object loader error
     if (!self.isUploading) {
         return;
@@ -576,6 +585,9 @@
             }
         }
     }
+    
+    [[UIApplication sharedApplication] endBackgroundTask:self.backgroundTask];
+    self.backgroundTask = UIBackgroundTaskInvalid;
 }
 
 #pragma mark - NSObject lifecycle


### PR DESCRIPTION
This should prevent uploads from being cancelled when the app enters the background.
