### PR TITLE
Single-line labels for iPad; wider cells for other screens

### DIFF
--- a/INaturalistIOS/Controllers/Media Picker/MediaPickerViewController.swift
+++ b/INaturalistIOS/Controllers/Media Picker/MediaPickerViewController.swift
@@ -43,6 +43,10 @@ class MediaPickerViewController: UIViewController {
     }
 }
 
+func isRegularScreen() -> Bool {
+    return UIScreen.main.traitCollection.horizontalSizeClass == .regular && UIScreen.main.traitCollection.verticalSizeClass == .regular
+}
+
 extension MediaPickerViewController: UICollectionViewDataSource {
     func numberOfSections(in collectionView: UICollectionView) -> Int {
         return 1
@@ -155,10 +159,10 @@ extension MediaPickerViewController: UICollectionViewDelegate {
 
 extension MediaPickerViewController: UICollectionViewDelegateFlowLayout {
     var cellWidth: CGFloat {
-        if UIScreen.main.traitCollection.horizontalSizeClass == .regular && UIScreen.main.traitCollection.verticalSizeClass == .regular {
+        if isRegularScreen() {
             return 120.0
         } else {
-            return 70.0
+            return 80
         }
     }
 
@@ -201,7 +205,7 @@ class MediaPickerCell: UICollectionViewCell {
         let iconImageView = UIImageView(frame: .zero)
         iconImageView.contentMode = .center
         let titleLabel = UILabel(frame: .zero)
-        titleLabel.numberOfLines = 2
+        titleLabel.numberOfLines = isRegularScreen() ? 1 : 2
         titleLabel.textAlignment = .center
         titleLabel.adjustsFontSizeToFitWidth = true
         


### PR DESCRIPTION
With the caveat that I *really* should not be touching code in this repo, do you think this is an improvement? I'm basically trying to avoid wrapping text on larger screens where it doesn't seem necessary, and creating a little more width for the text on smaller screens. Seemed to fit on an iPhone SE, but maybe there's something smaller I should be testing.