### PR TITLE
Github "Issues" templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug Report
+about: Report a Bug or Error
+title: ''
+labels: bugs
+assignees: ''
+
+---
+
+**Describe the Bug**
+A clear and concise description of what the bug is.
+
+**Steps to Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Device and IOS Version:**
+ [e.g. iOS]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature Request
+about: Suggest an Enhancement, Feature, or Improvement
+title: ''
+labels: enhancement, features, improvements
+assignees: ''
+
+---
+
+**Summary: Describe the feature you'd like added to this project**
+A clear and concise description of what the problem is.
+
+**Links to other examples, if applicable**
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Github Issue templates for reporting bugs and features requests

[Useful for standardizing and organizing issues](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository)